### PR TITLE
fix/error-handling

### DIFF
--- a/AWS/aws_cspm_benchmark.py
+++ b/AWS/aws_cspm_benchmark.py
@@ -1,3 +1,4 @@
+# noqa: C901
 """
 aws-cspm-benchmark.py
 

--- a/AWS/aws_cspm_benchmark.py
+++ b/AWS/aws_cspm_benchmark.py
@@ -1,4 +1,3 @@
-# noqa: C901
 """
 aws-cspm-benchmark.py
 
@@ -226,7 +225,7 @@ class AWSHandle:
 
 args = parse_args()
 
-for aws in AWSOrgAccess().accounts():
+for aws in AWSOrgAccess().accounts():  # noqa: C901
     if args.regions:
         regions = [x.strip() for x in args.regions.split(',')]
     else:

--- a/AWS/requirements.txt
+++ b/AWS/requirements.txt
@@ -1,2 +1,3 @@
 tabulate
 boto3
+botocore


### PR DESCRIPTION
- Handle access denied errors and continue when SCP blocks regions
- Handle AWSOrganizationsNotInUseException and continue when account is not a member of an AWS Organization
- Botocore requirement

[Script fails in individual AWS accounts](https://github.com/CrowdStrike/cloud-resource-estimator/issues/52)
[Skip regions deactivated via SCP](https://github.com/CrowdStrike/cloud-resource-estimator/issues/51)